### PR TITLE
Escape container name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
       uses: azure/CLI@v1
       with:
         inlineScript: |
-            az storage blob upload-batch --account-name ${{ env.STORAGE_ACCOUNT_NAME }} -d ${{ env.STORAGE_CONTAINER_NAME }} -s .
+            az storage blob upload-batch --account-name ${{ env.STORAGE_ACCOUNT_NAME }} -d '${{ env.STORAGE_CONTAINER_NAME }}' -s .
 
     - name: Azure log out
       run: |


### PR DESCRIPTION
Otherwise `$root` gets interpreted as a variable.
