### PR TITLE
Use lint-actions-powershell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
 
     - name: Checkout repo
       uses: actions/checkout@v4
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Create version file
       shell: pwsh
@@ -58,14 +61,26 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        filter: 'tree:0'
+        show-progress: false
 
     - name: Add actionlint problem matcher
       run: echo "::add-matcher::.github/actionlint-matcher.json"
 
     - name: Lint workflows
-      uses: docker://rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9 # v1.7.7
+      uses: docker://rhysd/actionlint:1.7.7
       with:
         args: -color
+
+    - name: Lint PowerShell in workflows
+      uses: martincostello/lint-actions-powershell@v1
+      with:
+        treat-warnings-as-errors: true
+
+    - name: Lint PowerShell scripts
+      shell: pwsh
+      run: Invoke-ScriptAnalyzer -Path . -Recurse -IncludeDefaultRules -ReportSummary -Severity @('Error','Warning') -EnableExit
 
   deploy:
     if: github.event.repository.fork == false && github.ref_name == 'deploy'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       shell: pwsh
       run: |
         $root = Resolve-Path "content"
-        [IO.Directory]::GetFiles($root.Path, "*.*", 'AllDirectories') | % { Copy-Item $_ -Destination (Join-Path "${env:STAGING_DIRECTORY}" ($_.Substring($root.Path.Length + 1).ToLowerInvariant().Replace("\", "_"))) }
+        [IO.Directory]::GetFiles($root.Path, "*.*", 'AllDirectories') | ForEach-Object { Copy-Item $_ -Destination (Join-Path "${env:STAGING_DIRECTORY}" ($_.Substring($root.Path.Length + 1).ToLowerInvariant().Replace("\", "_"))) }
 
     - name: Publish content
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Use martincostello/lint-actions-powershell to lint PowerShell code embedded in GitHub Actions workflow files.
- Add filter and hide progress when checking out code.